### PR TITLE
Add inline prop to Readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ export const ArgentinianFlag = () => <CircleFlag countryCode="ar" height="35" cd
 import React from 'react'
 import { CircleFlag } from 'react-circle-flags'
 
-export const ArgentinianFlag = () => <CircleFlag countryCode="ar" height="35" cdnUrl="https://magic-cdn.com/flags/" />
+export const ArgentinianFlag = () => <CircleFlag inline countryCode="ar" height="35" cdnUrl="https://magic-cdn.com/flags/" />
 ```
 
 You can pass all the react's `React.DetailedHTMLProps<React.ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>` props to CircleFlag. :rocket:


### PR DESCRIPTION
As mentioned when [it was introduced](https://github.com/on-the-edge-cloud/react-circle-flags/issues/55#issuecomment-3850098768)

Haven't tested it locally as I ended up not needing to implement flags yet but the duplicate examples popped out when reviewing the docs :) 